### PR TITLE
Kafka Produce, Consuming 개발

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.3</version>
+        <version>3.0.1</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.example</groupId>
@@ -13,19 +13,6 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>kafkaProducer</name>
     <description>kafkaProducer</description>
-    <url/>
-    <licenses>
-        <license/>
-    </licenses>
-    <developers>
-        <developer/>
-    </developers>
-    <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
-    </scm>
     <properties>
         <java.version>17</java.version>
     </properties>
@@ -34,11 +21,31 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-streams</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
         </dependency>
     </dependencies>
 

--- a/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
+++ b/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
@@ -1,0 +1,54 @@
+package com.example.kafkaproducer.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean
+    public KafkaTemplate<String, Object> KafkaTemplateForGeneral() {
+        return new KafkaTemplate<String, Object>(ProducerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> ProducerFactory() {
+        Map<String, Object> myConfig = new HashMap<>();
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+
+        return new DefaultKafkaProducerFactory<>(myConfig);
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> ConsumerFactory() {
+        Map<String, Object> myConfig = new HashMap<>();
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+        myConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        myConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+        return new DefaultKafkaConsumerFactory<>(myConfig);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, Object> myfactory = new ConcurrentKafkaListenerContainerFactory<>();
+        myfactory.setConsumerFactory(ConsumerFactory());
+        return myfactory;
+    }
+
+
+}

--- a/src/main/java/com/example/kafkaproducer/controller/ProducerController.java
+++ b/src/main/java/com/example/kafkaproducer/controller/ProducerController.java
@@ -1,0 +1,23 @@
+package com.example.kafkaproducer.controller;
+
+import com.example.kafkaproducer.service.Producer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ProducerController {
+
+    Producer producer;
+
+    @Autowired
+    ProducerController(Producer producer) {
+        this.producer = producer;
+    }
+
+    @PostMapping("/message")
+    public void PublishMessage(@RequestParam String msg) {
+        producer.pub(msg);
+    }
+}

--- a/src/main/java/com/example/kafkaproducer/service/ConsumerService.java
+++ b/src/main/java/com/example/kafkaproducer/service/ConsumerService.java
@@ -1,0 +1,14 @@
+package com.example.kafkaproducer.service;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ConsumerService {
+
+    @KafkaListener(topics = "kafkaProducer", groupId = "spring")
+    public void consumer(String message) {
+        System.out.println(String.format("Subscribed : %s", message));
+
+    }
+}

--- a/src/main/java/com/example/kafkaproducer/service/Producer.java
+++ b/src/main/java/com/example/kafkaproducer/service/Producer.java
@@ -1,0 +1,27 @@
+package com.example.kafkaproducer.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class Producer {
+    String topicName = "kafkaProducer";
+
+    private KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Autowired
+    public Producer(KafkaTemplate kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+    public void pub(String msg) {
+        System.out.println("Sending message: " + msg + " to topic: " + topicName);
+        try {
+            kafkaTemplate.send(topicName, msg).get(); // .get()을 사용하여 동기적으로 결과를 기다림
+            System.out.println("Message sent successfully");
+        } catch (Exception e) {
+            System.err.println("Error sending message: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
이 PR은 Kafka Produce와 Consuming 개발 내용을 포함한다.

- KafkaConfig 추가: Kafka 프로듀서 및 컨슈머 설정을 위한 클래스 추가. 이를 통해 Kafka와의 연결 및 메시지 처리를 효율적으로 관리
- ProducerController 구현: 외부 요청을 받아 Kafka 토픽으로 메시지를 발행하는 REST 컨트롤러 구현
- ConsumerService 및 Producer 서비스 로직 추가: Kafka에서 메시지를 수신하는 ConsumerService와 메시지를 발행하는 Producer 클래스를 구현.
- 의존성 추가: `spring-kafka`, `kafka-streams` 등 Kafka 작업에 필요한 의존성을 `pom.xml`에 추가.
- pom.xml 설정 변경: Spring Boot 버전을 3.0.1로 조정하고, 프로젝트 설정을 최신화하여 안정성 및 호환성을 개선.