### PR TITLE
Kafka Stream을 활용한 KStream 개발(1)

### DIFF
--- a/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
+++ b/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
@@ -2,12 +2,17 @@ package com.example.kafkaproducer.config;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
 import org.springframework.kafka.core.*;
 
 import java.util.HashMap;
@@ -15,40 +20,52 @@ import java.util.Map;
 
 @Configuration
 @EnableKafka
+@EnableKafkaStreams
 public class KafkaConfig {
 
-    @Bean
-    public KafkaTemplate<String, Object> KafkaTemplateForGeneral() {
-        return new KafkaTemplate<String, Object>(ProducerFactory());
+    @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+    public KafkaStreamsConfiguration myKStreamConfig() {
+        Map<String, Object> myKStreamConfig = new HashMap<>();
+        myKStreamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-test");
+        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+        myKStreamConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        myKStreamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+        myKStreamConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);
+        return new KafkaStreamsConfiguration(myKStreamConfig);
     }
 
-    @Bean
-    public ProducerFactory<String, Object> ProducerFactory() {
-        Map<String, Object> myConfig = new HashMap<>();
-        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
-        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-
-
-        return new DefaultKafkaProducerFactory<>(myConfig);
-    }
-
-    @Bean
-    public ConsumerFactory<String, Object> ConsumerFactory() {
-        Map<String, Object> myConfig = new HashMap<>();
-        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
-        myConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        myConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-
-        return new DefaultKafkaConsumerFactory<>(myConfig);
-    }
-
-    @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
-        ConcurrentKafkaListenerContainerFactory<String, Object> myfactory = new ConcurrentKafkaListenerContainerFactory<>();
-        myfactory.setConsumerFactory(ConsumerFactory());
-        return myfactory;
-    }
+//    @Bean
+//    public KafkaTemplate<String, Object> KafkaTemplateForGeneral() {
+//        return new KafkaTemplate<String, Object>(ProducerFactory());
+//    }
+//
+//    @Bean
+//    public ProducerFactory<String, Object> ProducerFactory() {
+//        Map<String, Object> myConfig = new HashMap<>();
+//        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+//        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+//        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+//
+//
+//        return new DefaultKafkaProducerFactory<>(myConfig);
+//    }
+//
+//    @Bean
+//    public ConsumerFactory<String, Object> ConsumerFactory() {
+//        Map<String, Object> myConfig = new HashMap<>();
+//        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+//        myConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+//        myConfig.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+//
+//        return new DefaultKafkaConsumerFactory<>(myConfig);
+//    }
+//
+//    @Bean
+//    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+//        ConcurrentKafkaListenerContainerFactory<String, Object> myfactory = new ConcurrentKafkaListenerContainerFactory<>();
+//        myfactory.setConsumerFactory(ConsumerFactory());
+//        return myfactory;
+//    }
 
 
 }

--- a/src/main/java/com/example/kafkaproducer/service/ConsumerService.java
+++ b/src/main/java/com/example/kafkaproducer/service/ConsumerService.java
@@ -6,9 +6,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class ConsumerService {
 
-    @KafkaListener(topics = "kafkaProducer", groupId = "spring")
-    public void consumer(String message) {
-        System.out.println(String.format("Subscribed : %s", message));
-
-    }
+//    @KafkaListener(topics = "kafkaProducer", groupId = "spring")
+//    public void consumer(String message) {
+//        System.out.println(String.format("Subscribed : %s", message));
+//
+//    }
 }

--- a/src/main/java/com/example/kafkaproducer/service/StreamService.java
+++ b/src/main/java/com/example/kafkaproducer/service/StreamService.java
@@ -1,0 +1,25 @@
+package com.example.kafkaproducer.service;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Printed;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class StreamService {
+
+    private static final Serde<String> STRING_SERDE = Serdes.String();
+
+    @Autowired
+    public void buildPipeline(StreamsBuilder sb) {
+
+        KStream<String, String> myStream = sb.stream("test", Consumed.with(STRING_SERDE, STRING_SERDE));
+        myStream.print(Printed.toSysOut());
+        myStream.filter((key, value) -> value.contains("freeClass")).to("freeClassList");
+
+    }
+}


### PR DESCRIPTION
이 PR은 Kafka Stream을 활용한 KStream 개발의 첫 번째 파트를 다룬다.

`KafkaConfig`: 스트림 설정을 추가하여 Kafka 서버와 연결 및 스트림 처리를 위한 기본 설정을 정의
`StreamService`: 실제 스트림 파이프라인을 구축하여 특정 데이터를 필터링하고 결과를 'freeClassList' 토픽으로 전송
`ConsumerService`: 현재 프로젝트 단계에서는 사용하지 않는 Kafka 리스너를 주석 처리