### PR TITLE
Kafka Stream을 활용한 KStream 개발(2)

### DIFF
--- a/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
+++ b/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
@@ -27,7 +27,7 @@ public class KafkaConfig {
     public KafkaStreamsConfiguration myKStreamConfig() {
         Map<String, Object> myKStreamConfig = new HashMap<>();
         myKStreamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-test");
-        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
+        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,13.125.235.147:9092");
         myKStreamConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         myKStreamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         myKStreamConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);

--- a/src/main/java/com/example/kafkaproducer/service/StreamService.java
+++ b/src/main/java/com/example/kafkaproducer/service/StreamService.java
@@ -4,10 +4,13 @@ import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.JoinWindows;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.Printed;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.Duration;
 
 @Service
 public class StreamService {
@@ -17,9 +20,28 @@ public class StreamService {
     @Autowired
     public void buildPipeline(StreamsBuilder sb) {
 
-        KStream<String, String> myStream = sb.stream("test", Consumed.with(STRING_SERDE, STRING_SERDE));
-        myStream.print(Printed.toSysOut());
-        myStream.filter((key, value) -> value.contains("freeClass")).to("freeClassList");
+//        KStream<String, String> myStream = sb.stream("test", Consumed.with(STRING_SERDE, STRING_SERDE));
+//        myStream.print(Printed.toSysOut());
+//        myStream.filter((key, value) -> value.contains("freeClass")).to("freeClassList");
+//
+        KStream<String, String> leftStream = sb.stream("leftTopic",
+                Consumed.with(STRING_SERDE, STRING_SERDE))
+                .selectKey((k, v) -> v.substring(0, v.indexOf(":")));
+        // key:value --> 1:leftValue
+        KStream<String, String> rightStream = sb.stream("rightTopic",
+                Consumed.with(STRING_SERDE, STRING_SERDE))
+                .selectKey((k, v) -> v.substring(0, v.indexOf(":")));
+        // key:value --> 1:rightValue
 
+        leftStream.print(Printed.toSysOut());
+        rightStream.print(Printed.toSysOut());
+
+        KStream<String, String> joinStream = leftStream.join
+                (rightStream, (leftValue, rightValue) -> leftValue + "_" + rightValue,
+                        JoinWindows.of(Duration.ofMinutes(1)));
+
+        joinStream.print(Printed.toSysOut());
+        joinStream.to("joinedMsg");
+        // 1:leftValue_1:rightValue
     }
 }


### PR DESCRIPTION
이 PR은 Kafka Streams 조인 기능을 추가한다.

- 조인 로직: 두 개의 스트림인 leftStream과 rightStream을 키를 기준으로 조인한다. 조인된 결과는 _를 사용하여 문자열을 연결한다.
- 스트림 설정: 조인을 위한 JoinWindows의 시간을 1분으로 설정하였고, 결과는 joinedMsg 토픽으로 전송된다.
- 키 선택 개선: selectKey를 사용하여 ":" 문자를 기준으로 키를 추출하도록 로직을 개선했다.