### PR TITLE
광고-구매 Join을 통한 광고효과 Streaming

### DIFF
--- a/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
+++ b/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
@@ -1,5 +1,7 @@
 package com.example.kafkaproducer.config;
 
+import com.example.kafkaproducer.util.PurchaseLogOneProductSerializer;
+import com.example.kafkaproducer.vo.PurchaseLogOneProduct;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
@@ -27,28 +29,28 @@ public class KafkaConfig {
     public KafkaStreamsConfiguration myKStreamConfig() {
         Map<String, Object> myKStreamConfig = new HashMap<>();
         myKStreamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-test");
-        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.156.112:9092");
+        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,13.124.211.91:9092,3.36.122.61:9092");
         myKStreamConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         myKStreamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         myKStreamConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);
         return new KafkaStreamsConfiguration(myKStreamConfig);
     }
 
-//    @Bean
-//    public KafkaTemplate<String, Object> KafkaTemplateForGeneral() {
-//        return new KafkaTemplate<String, Object>(ProducerFactory());
-//    }
-//
-//    @Bean
-//    public ProducerFactory<String, Object> ProducerFactory() {
-//        Map<String, Object> myConfig = new HashMap<>();
-//        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "13.124.237.39:9092,3.38.181.75:9092,3.35.220.144:9092");
-//        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-//        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
-//
-//
-//        return new DefaultKafkaProducerFactory<>(myConfig);
-//    }
+    @Bean
+    public KafkaTemplate<String, Object> KafkaTemplate() {
+        return new KafkaTemplate<String, Object>(ProducerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> ProducerFactory() {
+        Map<String, Object> myConfig = new HashMap<>();
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,13.124.211.91:9092,3.36.122.61:9092");
+        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, PurchaseLogOneProductSerializer.class);
+
+
+        return new DefaultKafkaProducerFactory<>(myConfig);
+    }
 //
 //    @Bean
 //    public ConsumerFactory<String, Object> ConsumerFactory() {

--- a/src/main/java/com/example/kafkaproducer/service/AdEvaluationService.java
+++ b/src/main/java/com/example/kafkaproducer/service/AdEvaluationService.java
@@ -1,0 +1,100 @@
+package com.example.kafkaproducer.service;
+
+import com.example.kafkaproducer.vo.EffectOrNot;
+import com.example.kafkaproducer.vo.PurchaseLog;
+import com.example.kafkaproducer.vo.PurchaseLogOneProduct;
+import com.example.kafkaproducer.vo.WatchingAdLog;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.*;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class AdEvaluationService {
+    // 광고 데이터는 중복 Join될 필요없다. --> Table
+    // 광고 이력이 먼저 들어온다.
+    // 구매 이력은 상품별로 들어오지 않는다. (복수개의 상품 존재) --> contain
+    // 광고에 머문 시간이 10초 이상되어야만 join 대상
+    // 특정가격 이상의 상품은 join 대상에서 제외 (100만원)
+    // 광고이력 : KTable(AdLog), 구매이력 : KTable(PurchaseLogOneProduct)
+    // filtering, 형 변환,
+    // EffectOrNot --> Json 형태로 Topic : AdEvaluationComplete
+
+    @Autowired
+    Producer myprdc;
+
+    @Autowired
+    public void buildPipeline(StreamsBuilder sb) {
+        JsonSerializer<EffectOrNot> effectSerializer = new JsonSerializer<>();
+        JsonSerializer<PurchaseLog> purchaseLogJsonSerializer = new JsonSerializer<>();
+        JsonSerializer<WatchingAdLog> watchingLogJsonSerializer = new JsonSerializer<>();
+        JsonSerializer<PurchaseLogOneProduct> purchaseLogOneProductJsonSerializer = new JsonSerializer<>();
+
+        JsonDeserializer<EffectOrNot> effectDeserializer = new JsonDeserializer<>(EffectOrNot.class);
+        JsonDeserializer<PurchaseLog> purchaseLogDeserializer = new JsonDeserializer<>(PurchaseLog.class);
+        JsonDeserializer<WatchingAdLog> watchingLogDeserializer = new JsonDeserializer<>(WatchingAdLog.class);
+        JsonDeserializer<PurchaseLogOneProduct> purchaseLogOneProductJsonDeserializer = new JsonDeserializer<>(PurchaseLogOneProduct.class);
+
+        Serde<EffectOrNot> effectOrNotSerde = Serdes.serdeFrom(effectSerializer, effectDeserializer);
+        Serde<PurchaseLog> purchaseLogSerde = Serdes.serdeFrom(purchaseLogJsonSerializer, purchaseLogDeserializer);
+        Serde<WatchingAdLog> watchingAdLogSerde = Serdes.serdeFrom(watchingLogJsonSerializer, watchingLogDeserializer);
+        Serde<PurchaseLogOneProduct> purchaseLogOneProductSerde = Serdes.serdeFrom(purchaseLogOneProductJsonSerializer, purchaseLogOneProductJsonDeserializer);
+
+        // adLog stream --> table
+        KTable<String, WatchingAdLog> adTable = sb.stream("adLog", Consumed.with(Serdes.String(), watchingAdLogSerde))
+                .selectKey((k,v) -> v.getUserId() + "_" + v.getProductId())
+                .toTable(Materialized.<String, WatchingAdLog, KeyValueStore<Bytes, byte[]>>as("adStore")
+                        .withKeySerde(Serdes.String())
+                        .withValueSerde(watchingAdLogSerde)
+                );
+
+        KStream<String, PurchaseLog> purchaseLogKStream = sb.stream("purchaseLog", Consumed.with(Serdes.String(), purchaseLogSerde));
+
+        purchaseLogKStream.foreach((k, v) -> {
+            for (Map<String, String> prodInfo:v.getProductInfo()) {
+                if (Integer.valueOf(prodInfo.get("price")) < 1000000) {
+                    PurchaseLogOneProduct tempVo = new PurchaseLogOneProduct();
+                    tempVo.setUserId(v.getUserId());
+                    tempVo.setProductId(prodInfo.get("productId"));
+                    tempVo.setOrderId(v.getOrderId());
+                    tempVo.setPrice(prodInfo.get("price"));
+                    tempVo.setPurchasedDt(v.getPurchasedDt());
+
+                    myprdc.sendJoinedMsg("purchaseLogOneProduct", tempVo);
+                }
+            }
+        });
+
+        KTable<String, PurchaseLogOneProduct> purchaseLogOneProductKTable = sb.stream("purchaseLogOneProduct", Consumed.with(Serdes.String(), purchaseLogOneProductSerde))
+                .selectKey((k, v) -> v.getUserId() + "_" + v.getProductId())
+                .toTable(Materialized.<String, PurchaseLogOneProduct, KeyValueStore<Bytes, byte[]>>as("purchaseLogStore")
+                                .withKeySerde(Serdes.String())
+                                .withValueSerde(purchaseLogOneProductSerde)
+                );
+
+        ValueJoiner<WatchingAdLog, PurchaseLogOneProduct, EffectOrNot> tableStreamJoiner = (leftValue, rightValue) -> {
+            EffectOrNot returnValue = new EffectOrNot();
+            returnValue.setUserId(leftValue.getUserId());
+            returnValue.setAdId(leftValue.getAdId());
+            returnValue.setOrderId(rightValue.getOrderId());
+            Map<String, String> tempProdInfo = new HashMap<>();
+            tempProdInfo.put("productId", rightValue.getProductId());
+            tempProdInfo.put("price", rightValue.getPrice());
+            returnValue.setProductInfo(tempProdInfo);
+            return returnValue;
+        };
+
+        adTable.join(purchaseLogOneProductKTable, tableStreamJoiner)
+                .toStream().to("AdEvaluationComplete", Produced.with(Serdes.String(), effectOrNotSerde));
+    }
+}

--- a/src/main/java/com/example/kafkaproducer/service/KTableService.java
+++ b/src/main/java/com/example/kafkaproducer/service/KTableService.java
@@ -8,22 +8,22 @@ import org.apache.kafka.streams.kstream.ValueJoiner;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-@Service
-public class KTableService {
+//@Service
+//public class KTableService {
 
-    @Autowired
-    public void buildPipeline(StreamsBuilder sb) {
-
-        KTable<String, String> leftTable = sb.stream("leftTopic1", Consumed.with(Serdes.String(), Serdes.String())).toTable();
-        KTable<String, String> rightTable = sb.stream("rightTopic1", Consumed.with(Serdes.String(), Serdes.String())).toTable();
-
-        ValueJoiner<String, String, String> stringJoiner = (leftValue, rightValue) -> {
-            return "[StringJoiner]" + leftValue + "-" + rightValue;
-        };
-
-        KTable<String, String> joinTable = leftTable.join(rightTable, stringJoiner);
-        joinTable.toStream().to("joinedMsg1");
-
-    }
-}
+//    @Autowired
+//    public void buildPipeline(StreamsBuilder sb) {
+//
+//        KTable<String, String> leftTable = sb.stream("leftTopic1", Consumed.with(Serdes.String(), Serdes.String())).toTable();
+//        KTable<String, String> rightTable = sb.stream("rightTopic1", Consumed.with(Serdes.String(), Serdes.String())).toTable();
+//
+//        ValueJoiner<String, String, String> stringJoiner = (leftValue, rightValue) -> {
+//            return "[StringJoiner]" + leftValue + "-" + rightValue;
+//        };
+//
+//        KTable<String, String> joinTable = leftTable.join(rightTable, stringJoiner);
+//        joinTable.toStream().to("joinedMsg1");
+//
+//    }
+//}
 

--- a/src/main/java/com/example/kafkaproducer/service/Producer.java
+++ b/src/main/java/com/example/kafkaproducer/service/Producer.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class Producer {
-    String topicName = "kafkaProducer";
+    String topicName = "defaultTopic";
 
     private KafkaTemplate<String, Object> kafkaTemplate;
 
@@ -14,14 +14,9 @@ public class Producer {
     public Producer(KafkaTemplate kafkaTemplate) {
         this.kafkaTemplate = kafkaTemplate;
     }
-    public void pub(String msg) {
-        System.out.println("Sending message: " + msg + " to topic: " + topicName);
-        try {
-            kafkaTemplate.send(topicName, msg).get(); // .get()을 사용하여 동기적으로 결과를 기다림
-            System.out.println("Message sent successfully");
-        } catch (Exception e) {
-            System.err.println("Error sending message: " + e.getMessage());
-            e.printStackTrace();
-        }
+    public void pub(String msg) {kafkaTemplate.send(topicName, msg);}
+
+    public void sendJoinedMsg(String TopicName, Object msg) {
+        kafkaTemplate.send(TopicName, msg);
     }
 }

--- a/src/main/java/com/example/kafkaproducer/util/CustomSerializer.java
+++ b/src/main/java/com/example/kafkaproducer/util/CustomSerializer.java
@@ -1,0 +1,34 @@
+package com.example.kafkaproducer.util;
+
+import com.example.kafkaproducer.vo.PurchaseLogOneProduct;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class CustomSerializer implements Serializer<PurchaseLogOneProduct> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, PurchaseLogOneProduct data) {
+        try {
+            if (data == null){
+                return null;
+            }
+            System.out.println("Serializing...");
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new SecurityException("Error when serializing MessageDto to byte[]");
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/example/kafkaproducer/util/PurchaseLogOneProductSerializer.java
+++ b/src/main/java/com/example/kafkaproducer/util/PurchaseLogOneProductSerializer.java
@@ -1,0 +1,32 @@
+package com.example.kafkaproducer.util;
+
+import com.example.kafkaproducer.vo.PurchaseLogOneProduct;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class PurchaseLogOneProductSerializer implements Serializer<PurchaseLogOneProduct> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, PurchaseLogOneProduct data) {
+        try {
+            if (data == null){
+                return null;
+            }
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new SecurityException("Exception Occured");
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/example/kafkaproducer/vo/EffectOrNot.java
+++ b/src/main/java/com/example/kafkaproducer/vo/EffectOrNot.java
@@ -1,0 +1,19 @@
+package com.example.kafkaproducer.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.Map;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class EffectOrNot {
+
+    String adId;  // ad-101
+    String userId; //
+    String orderId;
+    Map<String, String> productInfo;
+}

--- a/src/main/java/com/example/kafkaproducer/vo/PurchaseLog.java
+++ b/src/main/java/com/example/kafkaproducer/vo/PurchaseLog.java
@@ -1,0 +1,20 @@
+package com.example.kafkaproducer.vo;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.Map;
+
+@Data
+public class PurchaseLog {
+    // SAMPLE DATA
+    // { "orderId": "od-0005", "userId": "uid-0005",  "productInfo": [{"productId": "pg-0023", "price":"12000"}, {"productId":"pg-0022", "price":"13500"}],  "purchasedDt": "20230201070000",  "price": 24000}
+
+    String orderId; // od-0001
+    String userId; // uid-0001
+//    ArrayList<String> productId; // {pg-0001, pg-0002}
+    ArrayList<Map<String, String>> productInfo;
+    String purchasedDt; // 2024201070000
+//    Long price; // 24000
+
+}

--- a/src/main/java/com/example/kafkaproducer/vo/PurchaseLogOneProduct.java
+++ b/src/main/java/com/example/kafkaproducer/vo/PurchaseLogOneProduct.java
@@ -1,0 +1,14 @@
+package com.example.kafkaproducer.vo;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+
+@Data
+public class PurchaseLogOneProduct {
+    String orderId; //  od-0001
+    String userId; // uid-0001
+    String productId; // pg-0001
+    String purchasedDt; // 20230201070000
+    String price; // 24000
+}

--- a/src/main/java/com/example/kafkaproducer/vo/WatchingAdLog.java
+++ b/src/main/java/com/example/kafkaproducer/vo/WatchingAdLog.java
@@ -1,0 +1,17 @@
+package com.example.kafkaproducer.vo;
+
+import lombok.Data;
+
+@Data
+public class WatchingAdLog {
+
+    // SAMPLE DATA
+    // {"userId": "uid-0007", "productId": "pg-0007", "adId": "ad-101", "adType": "banner", "watchingTime": "30", "watchingDt": "20240201070000"}
+
+    String userId; // uid-0001
+    String productId; // pg-0001
+    String adId; // ad-101
+    String adType;  // banner, clip, main, live
+    String watchingTime; // 머문시간
+    String watchingDt; // 2024201070000
+}


### PR DESCRIPTION
이 PR은 Kafka 스트리밍을 통해 광고와 구매 데이터를 조인하여 광고 효과를 분석하는 기능을 구현하고, 사용하지 않는 코드를 주석 처리한다.

- Kafka 설정 및 직렬화 클래스 추가
- 광고 및 구매 로그 처리 로직 구현
- 광고 효과 평가를 위한 조인 로직 구현
- 테스트를 위한 Kafka 토픽 생성 및 실행 절차 추가
- KTableService 클래스 주석 처리 (현재 사용하지 않음)