### PR TITLE
대량 Kafka Message Join Test

### DIFF
--- a/src/main/java/com/example/kafkaproducer/KafkaProducerApplication.java
+++ b/src/main/java/com/example/kafkaproducer/KafkaProducerApplication.java
@@ -2,8 +2,10 @@ package com.example.kafkaproducer;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class KafkaProducerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
+++ b/src/main/java/com/example/kafkaproducer/config/KafkaConfig.java
@@ -1,7 +1,8 @@
 package com.example.kafkaproducer.config;
 
 import com.example.kafkaproducer.util.PurchaseLogOneProductSerializer;
-import com.example.kafkaproducer.vo.PurchaseLogOneProduct;
+import com.example.kafkaproducer.util.PurchaseLogSerializer;
+import com.example.kafkaproducer.util.WatchingAdLogSerializer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.Serdes;
@@ -28,29 +29,59 @@ public class KafkaConfig {
     @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
     public KafkaStreamsConfiguration myKStreamConfig() {
         Map<String, Object> myKStreamConfig = new HashMap<>();
-        myKStreamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "stream-test");
-        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,13.124.211.91:9092,3.36.122.61:9092");
+        myKStreamConfig.put(StreamsConfig.APPLICATION_ID_CONFIG, "lecture-6");
+        myKStreamConfig.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,43.203.201.212:9092,3.36.122.61:9092");
         myKStreamConfig.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
         myKStreamConfig.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
-        myKStreamConfig.put(StreamsConfig.NUM_STREAM_THREADS_CONFIG, 3);
         return new KafkaStreamsConfiguration(myKStreamConfig);
     }
 
     @Bean
-    public KafkaTemplate<String, Object> KafkaTemplate() {
+    public KafkaTemplate<String, Object> KafkaTemplateForGeneral() {
         return new KafkaTemplate<String, Object>(ProducerFactory());
     }
 
     @Bean
     public ProducerFactory<String, Object> ProducerFactory() {
         Map<String, Object> myConfig = new HashMap<>();
-        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,13.124.211.91:9092,3.36.122.61:9092");
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,43.203.201.212:9092,3.36.122.61:9092");
         myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, PurchaseLogOneProductSerializer.class);
 
+        return new DefaultKafkaProducerFactory<>(myConfig);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> KafkaTemplateForWatchingAdLog() {
+        return new KafkaTemplate<String, Object>(ProducerFactoryForWatchingAdLog());
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> ProducerFactoryForWatchingAdLog() {
+        Map<String, Object> myConfig = new HashMap<>();
+
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,43.203.201.212:9092,3.36.122.61:9092");
+        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, WatchingAdLogSerializer.class);
 
         return new DefaultKafkaProducerFactory<>(myConfig);
     }
+
+    @Bean
+    public KafkaTemplate<String, Object> KafkaTemplateForPurchaseLog() {
+        return new KafkaTemplate<String, Object>(ProducerFactoryForPurchaseLog());
+    }
+    @Bean
+    public ProducerFactory<String, Object> ProducerFactoryForPurchaseLog() {
+        Map<String, Object> myConfig = new HashMap<>();
+
+        myConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "3.39.223.252:9092,43.203.201.212:9092,3.36.122.61:9092");
+        myConfig.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        myConfig.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, PurchaseLogSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(myConfig);
+    }
+
 //
 //    @Bean
 //    public ConsumerFactory<String, Object> ConsumerFactory() {

--- a/src/main/java/com/example/kafkaproducer/service/AdEvaluationService.java
+++ b/src/main/java/com/example/kafkaproducer/service/AdEvaluationService.java
@@ -7,7 +7,6 @@ import com.example.kafkaproducer.vo.WatchingAdLog;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.*;
 import org.apache.kafka.streams.state.KeyValueStore;
@@ -16,85 +15,142 @@ import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.stereotype.Service;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Service
 public class AdEvaluationService {
-    // 광고 데이터는 중복 Join될 필요없다. --> Table
+    // 광고 데이터 중복 Join될 필요없다. --> Table
     // 광고 이력이 먼저 들어온다.
     // 구매 이력은 상품별로 들어오지 않는다. (복수개의 상품 존재) --> contain
-    // 광고에 머문 시간이 10초 이상되어야만 join 대상
-    // 특정가격 이상의 상품은 join 대상에서 제외 (100만원)
+    // 광고에 머문시간이 10초 이상되어야만 join 대상
+    // 특정가격이상의 상품은 join 대상에서 제외 (100만원)
     // 광고이력 : KTable(AdLog), 구매이력 : KTable(PurchaseLogOneProduct)
     // filtering, 형 변환,
     // EffectOrNot --> Json 형태로 Topic : AdEvaluationComplete
-
     @Autowired
     Producer myprdc;
-
     @Autowired
     public void buildPipeline(StreamsBuilder sb) {
+
+        //object의 형태별로 Serializer, Deserializer 를 설정합니다.
         JsonSerializer<EffectOrNot> effectSerializer = new JsonSerializer<>();
-        JsonSerializer<PurchaseLog> purchaseLogJsonSerializer = new JsonSerializer<>();
-        JsonSerializer<WatchingAdLog> watchingLogJsonSerializer = new JsonSerializer<>();
-        JsonSerializer<PurchaseLogOneProduct> purchaseLogOneProductJsonSerializer = new JsonSerializer<>();
+        JsonSerializer<PurchaseLog> purchaseLogSerializer = new JsonSerializer<>();
+        JsonSerializer<WatchingAdLog> watchingAdLogSerializer = new JsonSerializer<>();
+        JsonSerializer<PurchaseLogOneProduct> purchaseLogOneProductSerializer = new JsonSerializer<>();
 
         JsonDeserializer<EffectOrNot> effectDeserializer = new JsonDeserializer<>(EffectOrNot.class);
         JsonDeserializer<PurchaseLog> purchaseLogDeserializer = new JsonDeserializer<>(PurchaseLog.class);
-        JsonDeserializer<WatchingAdLog> watchingLogDeserializer = new JsonDeserializer<>(WatchingAdLog.class);
-        JsonDeserializer<PurchaseLogOneProduct> purchaseLogOneProductJsonDeserializer = new JsonDeserializer<>(PurchaseLogOneProduct.class);
+        JsonDeserializer<WatchingAdLog> watchingAdLogJsonDeserializer = new JsonDeserializer<>(WatchingAdLog.class);
+        JsonDeserializer<PurchaseLogOneProduct> purchaseLogOneProductDeserializer = new JsonDeserializer<>(PurchaseLogOneProduct.class);
 
         Serde<EffectOrNot> effectOrNotSerde = Serdes.serdeFrom(effectSerializer, effectDeserializer);
-        Serde<PurchaseLog> purchaseLogSerde = Serdes.serdeFrom(purchaseLogJsonSerializer, purchaseLogDeserializer);
-        Serde<WatchingAdLog> watchingAdLogSerde = Serdes.serdeFrom(watchingLogJsonSerializer, watchingLogDeserializer);
-        Serde<PurchaseLogOneProduct> purchaseLogOneProductSerde = Serdes.serdeFrom(purchaseLogOneProductJsonSerializer, purchaseLogOneProductJsonDeserializer);
+        Serde<PurchaseLog> purchaseLogSerde = Serdes.serdeFrom(purchaseLogSerializer, purchaseLogDeserializer);
+        Serde<WatchingAdLog> watchingAdLogSerde = Serdes.serdeFrom(watchingAdLogSerializer, watchingAdLogJsonDeserializer);
+        Serde<PurchaseLogOneProduct> purchaseLogOneProductSerdeSerde = Serdes.serdeFrom(purchaseLogOneProductSerializer, purchaseLogOneProductDeserializer);
 
-        // adLog stream --> table
+        // adLog topic 을 consuming 하여 KTable 로 받는다.
         KTable<String, WatchingAdLog> adTable = sb.stream("adLog", Consumed.with(Serdes.String(), watchingAdLogSerde))
-                .selectKey((k,v) -> v.getUserId() + "_" + v.getProductId())
-                .toTable(Materialized.<String, WatchingAdLog, KeyValueStore<Bytes, byte[]>>as("adStore")
+                .selectKey((k,v) -> v.getUserId() + "_" + v.getProductId()) // key를 userId+prodId로 생성해준다.
+                .filter((k,v)-> Integer.parseInt(v.getWatchingTime()) > 10) // 광고 시청시간이 10초 이상인 데이터만 Table에 담는다.
+                .toTable(Materialized.<String, WatchingAdLog, KeyValueStore<Bytes, byte[]>>as("adStore") // Key-Value Store로 만들어준다.
                         .withKeySerde(Serdes.String())
                         .withValueSerde(watchingAdLogSerde)
                 );
 
+        // purchaseLog topic 을 consuming 하여 KStream 으로 받는다.
         KStream<String, PurchaseLog> purchaseLogKStream = sb.stream("purchaseLog", Consumed.with(Serdes.String(), purchaseLogSerde));
 
-        purchaseLogKStream.foreach((k, v) -> {
-            for (Map<String, String> prodInfo:v.getProductInfo()) {
-                if (Integer.valueOf(prodInfo.get("price")) < 1000000) {
-                    PurchaseLogOneProduct tempVo = new PurchaseLogOneProduct();
-                    tempVo.setUserId(v.getUserId());
-                    tempVo.setProductId(prodInfo.get("productId"));
-                    tempVo.setOrderId(v.getOrderId());
-                    tempVo.setPrice(prodInfo.get("price"));
-                    tempVo.setPurchasedDt(v.getPurchasedDt());
+        // 해당 KStream의 매 Row(Msg)마다 하기의 내용을 수행한다.
+        purchaseLogKStream.foreach((k,v) -> {
 
-                    myprdc.sendJoinedMsg("purchaseLogOneProduct", tempVo);
+                    // value 의 product 개수만큼 반복하여 신규 VO에 값을 Binding 한다.
+                    for (Map<String, String> prodInfo:v.getProductInfo())   {
+                        // price 100000 미만인 경우만 하기의 내용을 수행합니다. 위 purchaseLogKStream에서 filter조건을 주고 받아도 무관하다.
+                        if (Integer.parseInt(prodInfo.get("price")) < 1000000) {
+                            PurchaseLogOneProduct tempVo = new PurchaseLogOneProduct();
+                            tempVo.setUserId(v.getUserId());
+                            tempVo.setProductId(prodInfo.get("productId"));
+                            tempVo.setOrderId(v.getOrderId());
+                            tempVo.setPrice(prodInfo.get("price"));
+                            tempVo.setPurchasedDt(v.getPurchasedDt());
+
+                            // 1개의 product로 나눈 데이터를 purchaseLogOneProduct Topic으로 produce 한다.
+                            myprdc.sendJoinedMsg("purchaseLogOneProduct", tempVo);
+
+                            // 하기의 method는 samplie Data를 생산하여 Topic에 넣는다. 1개 받으면 여러개를 생성하기 때문에 무한하게 생성헌다,
+//                            sendNewMsg();
+                        }
+                    }
                 }
-            }
-        });
+        );
 
-        KTable<String, PurchaseLogOneProduct> purchaseLogOneProductKTable = sb.stream("purchaseLogOneProduct", Consumed.with(Serdes.String(), purchaseLogOneProductSerde))
-                .selectKey((k, v) -> v.getUserId() + "_" + v.getProductId())
+        // product이 1개씩 나누어 producing 된 topic을 읽어 KTable 로 받아온다.
+        KTable<String, PurchaseLogOneProduct> purchaseLogOneProductKTable= sb.stream("purchaseLogOneProduct", Consumed.with(Serdes.String(), purchaseLogOneProductSerdeSerde))
+                // Stream의 key 지정
+                .selectKey((k,v)-> v.getUserId()+ "_" +v.getProductId())
+                // key-value Store로 이용이 가능하도록 생성
                 .toTable(Materialized.<String, PurchaseLogOneProduct, KeyValueStore<Bytes, byte[]>>as("purchaseLogStore")
-                                .withKeySerde(Serdes.String())
-                                .withValueSerde(purchaseLogOneProductSerde)
+                        .withKeySerde(Serdes.String())
+                        .withValueSerde(purchaseLogOneProductSerdeSerde)
                 );
 
+        // value joiner 를 통해 Left, Right 값을 통한 Output 결과값을 bind 하거나 join 조건을 설정할 수 있다.
         ValueJoiner<WatchingAdLog, PurchaseLogOneProduct, EffectOrNot> tableStreamJoiner = (leftValue, rightValue) -> {
             EffectOrNot returnValue = new EffectOrNot();
-            returnValue.setUserId(leftValue.getUserId());
+            returnValue.setUserId(rightValue.getUserId());
             returnValue.setAdId(leftValue.getAdId());
             returnValue.setOrderId(rightValue.getOrderId());
             Map<String, String> tempProdInfo = new HashMap<>();
             tempProdInfo.put("productId", rightValue.getProductId());
             tempProdInfo.put("price", rightValue.getPrice());
             returnValue.setProductInfo(tempProdInfo);
+            System.out.println("Joined!");
             return returnValue;
         };
 
-        adTable.join(purchaseLogOneProductKTable, tableStreamJoiner)
+        // table과 joiner를 입력해줍니다. stream join이 아니기에 window 설정은 불필요하다.
+        adTable.join(purchaseLogOneProductKTable,tableStreamJoiner)
+                // join 이 완료된 데이터를 AdEvaluationComplete Topic으로 전달한다.
                 .toStream().to("AdEvaluationComplete", Produced.with(Serdes.String(), effectOrNotSerde));
+    }
+
+    public void sendNewMsg() {
+        PurchaseLog tempPurchaseLog  = new PurchaseLog();
+        WatchingAdLog tempWatchingAdLog = new WatchingAdLog();
+
+        //랜덤한 ID를 생성하기 위해 아래의 함수를 사용한다.
+        // random Numbers for concatenation with attrs
+        Random rd = new Random();
+        int rdUidNumber = rd.nextInt(9999);
+        int rdOrderNumber = rd.nextInt(9999);
+        int rdProdIdNumber = rd.nextInt(9999);
+        int rdPriceIdNumber = rd.nextInt(90000)+10000;
+        int prodCnt = rd.nextInt(9)+1;
+        int watchingTime = rd.nextInt(55)+5;
+
+        // bind value for purchaseLog
+        tempPurchaseLog.setUserId("uid-" + String.format("%05d", rdUidNumber));
+        tempPurchaseLog.setPurchasedDt("20230101070000");
+        tempPurchaseLog.setOrderId("od-" + String.format("%05d", rdOrderNumber));
+        ArrayList<Map<String, String>> tempProdInfo = new ArrayList<>();
+        Map<String, String> tempProd = new HashMap<>();
+        for (int i=0; i<prodCnt; i++ ){
+            tempProd.put("productId", "pg-" + String.format("%05d", rdProdIdNumber));
+            tempProd.put("price", String.format("%05d", rdPriceIdNumber));
+            tempProdInfo.add(tempProd);
+        }
+        tempPurchaseLog.setProductInfo(tempProdInfo);
+
+        // bind value for watchingAdLog
+        tempWatchingAdLog.setUserId("uid-" + String.format("%05d", rdUidNumber));
+        tempWatchingAdLog.setProductId("pg-" + String.format("%05d", rdProdIdNumber));
+        tempWatchingAdLog.setAdId("ad-" + String.format("%05d",rdUidNumber) );
+        tempWatchingAdLog.setAdType("banner");
+        tempWatchingAdLog.setWatchingTime(String.valueOf(watchingTime));
+        tempWatchingAdLog.setWatchingDt("20230201070000");
+
+        // produce msg
+        myprdc.sendMsgForPurchaseLog("purchaseLog", tempPurchaseLog);
+        myprdc.sendMsgForWatchingAdLog("adLog", tempWatchingAdLog);
     }
 }

--- a/src/main/java/com/example/kafkaproducer/service/Producer.java
+++ b/src/main/java/com/example/kafkaproducer/service/Producer.java
@@ -1,22 +1,45 @@
 package com.example.kafkaproducer.service;
 
+import com.example.kafkaproducer.config.KafkaConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Service;
+import org.springframework.util.concurrent.ListenableFuture;
 
 @Service
 public class Producer {
+    private static final Logger logger = LoggerFactory.getLogger(Producer.class);
+
+    @Autowired
+    KafkaConfig myConfig;
+
     String topicName = "defaultTopic";
 
     private KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Autowired
-    public Producer(KafkaTemplate kafkaTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
-    }
-    public void pub(String msg) {kafkaTemplate.send(topicName, msg);}
+//    public Producer(KafkaTemplate kafkaTemplate) {
+//        this.kafkaTemplate = kafkaTemplate;
+//    }
 
-    public void sendJoinedMsg(String TopicName, Object msg) {
-        kafkaTemplate.send(TopicName, msg);
+    public void pub(String msg) {
+        kafkaTemplate = myConfig.KafkaTemplateForGeneral();
+        kafkaTemplate.send(topicName, msg);
+    }
+
+    public void sendJoinedMsg (String topicNm, Object msg) {
+        kafkaTemplate = myConfig.KafkaTemplateForGeneral();
+        kafkaTemplate.send(topicNm, msg);
+    }
+    public void sendMsgForWatchingAdLog (String topicNm, Object msg) {
+        kafkaTemplate = myConfig.KafkaTemplateForWatchingAdLog();
+        kafkaTemplate.send(topicNm, msg);
+    }
+
+    public void sendMsgForPurchaseLog (String topicNm, Object msg) {
+        kafkaTemplate = myConfig.KafkaTemplateForPurchaseLog();
+        kafkaTemplate.send(topicNm, msg);
     }
 }

--- a/src/main/java/com/example/kafkaproducer/util/PurchaseLogSerializer.java
+++ b/src/main/java/com/example/kafkaproducer/util/PurchaseLogSerializer.java
@@ -1,0 +1,32 @@
+package com.example.kafkaproducer.util;
+
+import com.example.kafkaproducer.vo.PurchaseLog;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class PurchaseLogSerializer implements Serializer<PurchaseLog> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, PurchaseLog data) {
+        try {
+            if (data == null){
+                return null;
+            }
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new SecurityException("Exception Occured");
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/example/kafkaproducer/util/WatchingAdLogSerializer.java
+++ b/src/main/java/com/example/kafkaproducer/util/WatchingAdLogSerializer.java
@@ -1,0 +1,32 @@
+package com.example.kafkaproducer.util;
+
+import com.example.kafkaproducer.vo.WatchingAdLog;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.Map;
+
+public class WatchingAdLogSerializer implements Serializer<WatchingAdLog> {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, WatchingAdLog data) {
+        try {
+            if (data == null){
+                return null;
+            }
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new SecurityException("Exception Occured");
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+
+}

--- a/src/main/java/com/example/kafkaproducer/vo/PurchaseLog.java
+++ b/src/main/java/com/example/kafkaproducer/vo/PurchaseLog.java
@@ -1,5 +1,6 @@
 package com.example.kafkaproducer.vo;
 
+
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -9,12 +10,10 @@ import java.util.Map;
 public class PurchaseLog {
     // SAMPLE DATA
     // { "orderId": "od-0005", "userId": "uid-0005",  "productInfo": [{"productId": "pg-0023", "price":"12000"}, {"productId":"pg-0022", "price":"13500"}],  "purchasedDt": "20230201070000",  "price": 24000}
-
-    String orderId; // od-0001
+    String orderId; //  od-0001
     String userId; // uid-0001
-//    ArrayList<String> productId; // {pg-0001, pg-0002}
-    ArrayList<Map<String, String>> productInfo;
-    String purchasedDt; // 2024201070000
-//    Long price; // 24000
-
+    //ArrayList<String> productId; // {pg-0001, pg-0002}
+    ArrayList<Map<String, String>> productInfo;  // [ {"productid":"pg-0001", "price":"24000"}, {}... ]
+    String purchasedDt; // 20230201070000
+    //Long price; // 24000
 }


### PR DESCRIPTION
이 PR은 대량의 Kafka 메시지를 처리하고, 광고 로그와 구매 로그를 조인하여 광고 효과를 분석하는 테스트를 위한 기능을 구현한다. 또한, 시스템 성능 향상을 위해 캐시 설정을 추가하고 데이터 구조를 최적화하였다.

- AdEvaluationService: 광고 로그 및 구매 로그의 스트림 처리 및 조인 로직 구현
- Producer: Kafka 프로듀서를 통한 메시지 전송 기능 구현
- KafkaConfig: Kafka 스트림과 프로듀서 설정 추가 및 여러 직렬화 로직 적용
- 직렬화 클래스: PurchaseLog 및 WatchingAdLog 직렬화 클래스 추가
- KafkaProducerApplication: 캐시 활성화를 위한 @EnableCaching 설정 추가
- PurchaseLog: productInfo 필드 주석 추가 및 코드 정리